### PR TITLE
Fix problem caused by race condition in scope creation

### DIFF
--- a/src/main/java/org/red5/server/scope/ScopeResolver.java
+++ b/src/main/java/org/red5/server/scope/ScopeResolver.java
@@ -95,16 +95,14 @@ public class ScopeResolver implements IScopeResolver {
 					// skip empty path elements
 					continue;
 				}
-				if (scope.hasChildScope(child)) {
-					scope = scope.getScope(child);
-				} else if (!scope.equals(root)) {
-					// no need for sync here, scope.children is concurrent
-					if (scope.createChildScope(child)) {
-						scope = scope.getScope(child);
-					}
+				// if scope does not exist and we are not in the root, create a child scope
+				if (!scope.hasChildScope(child) && !scope.equals(root)) {
+					scope.createChildScope(child);
 				}
-				// if the scope is still equal to root then the room was not found
-				if (scope == root) {
+				// get child scope
+				scope = scope.getScope(child);
+				// if the scope is null then the room was not found
+				if (scope == null) {
 					throw new ScopeNotFoundException(scope, child);
 				}
 				// some scopes don't implement IScope, such as SharedObjectScope


### PR DESCRIPTION
Now the scope is set whether or not the scope creation is successful.
This ensures that if two connections try to create the same scope at
the same time, both will end up with the right scope.

This fixes the bug reported at Red5/red5-server#14.
