### PR TITLE
Fix concurrence problem on BroadcastScope creation

### DIFF
--- a/src/main/java/org/red5/server/stream/ProviderService.java
+++ b/src/main/java/org/red5/server/stream/ProviderService.java
@@ -82,11 +82,13 @@ public class ProviderService implements IProviderService {
 		IBroadcastScope broadcastScope = scope.getBroadcastScope(name);
 		if (broadcastScope == null) {
 			if (needCreate) {
-				// re-check if another thread already created the scope
-				broadcastScope = scope.getBroadcastScope(name);
-				if (broadcastScope == null) {
-					broadcastScope = new BroadcastScope(scope, name);
-					scope.addChildScope(broadcastScope);
+				synchronized(scope) {
+					// re-check if another thread already created the scope
+					broadcastScope = scope.getBroadcastScope(name);
+					if (broadcastScope == null) {
+						broadcastScope = new BroadcastScope(scope, name);
+						scope.addChildScope(broadcastScope);
+					}
 				}
 			} else {
 				return null;


### PR DESCRIPTION
Without the synchronization multiple BroadcastScopes might be created with the same name. In this case, simultaneous calls to getLiveProviderInput return different BroadcastScope objects. The synchronization using scope solve this problem.

The problem was observed when two or more clients were requesting a video stream, through play, that was not present in the server yet. The problem observed was that only one client was able to receive the video.

This patch solves this problem.
