### PR TITLE
Updated policy files from red5.jar to red5-server.jar and red5-service.jar

### DIFF
--- a/src/main/server/conf/catalina.policy
+++ b/src/main/server/conf/catalina.policy
@@ -36,15 +36,27 @@ grant codeBase "file:${java.home}/lib/ext/-" {
 
 
 // These permissions apply to the main code
-grant codeBase "file:red5.jar" {
+grant codeBase "file:red5-server.jar" {
   permission java.security.AllPermission;
 };
 
-grant codeBase "file:${red5.home}/red5.jar" {
+grant codeBase "file:${red5.home}/red5-server.jar" {
   permission java.security.AllPermission;
 };
 
-grant codeBase "file:${red5.root}/red5.jar" {
+grant codeBase "file:${red5.root}/red5-server.jar" {
+  permission java.security.AllPermission;
+};
+
+grant codeBase "file:red5-service.jar" {
+  permission java.security.AllPermission;
+};
+
+grant codeBase "file:${red5.home}/red5-service.jar" {
+  permission java.security.AllPermission;
+};
+
+grant codeBase "file:${red5.root}/red5-service.jar" {
   permission java.security.AllPermission;
 };
 

--- a/src/main/server/conf/red5.policy
+++ b/src/main/server/conf/red5.policy
@@ -36,11 +36,11 @@ grant codeBase "file:${java.home}/lib/ext/-" {
 
 
 // These permissions apply to the main code
-grant codeBase "file:boot.jar" {
+grant codeBase "file:red5-server.jar" {
   permission java.security.AllPermission;
 };
 
-grant codeBase "file:red5.jar" {
+grant codeBase "file:red5-service.jar" {
   permission java.security.AllPermission;
 };
 
@@ -128,7 +128,8 @@ grant {
   permission java.net.SocketPermission "red5.googlecode.com:80", "connect,resolve";
   permission java.net.SocketPermission "www.springframework.org:80", "connect,resolve";
 
-  permission java.io.FilePermission "file:red5.jar", "read";
+  permission java.io.FilePermission "file:red5-server.jar", "read";
+  permission java.io.FilePermission "file:red5-service.jar", "read";
   permission java.io.FilePermission "file:conf/red5.properties", "read";
   
   permission java.io.FilePermission "file:webapps/installer/WEB-INF/cache", "read,write";


### PR DESCRIPTION
The red5.jar is replaced with red5-server.jar and red5-service.jar. Red5 service couldn't start up with security option. see also https://github.com/Red5/red5-server/issues/5#issuecomment-57411200

``` ini
-Djava.security.manager
-Djava.security.policy=%RED5_HOME%/conf/red5.policy
```
