### PR TITLE
Removes Google Code link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Support via plugin:
  * [HLS](https://github.com/Red5/red5-hls-plugin)
  * [RTSP (From Axis-type cameras)](https://github.com/Red5/red5-rtsp-restreamer)
 
-Some of the Red5 project information continues to reside on [Google Code](https://code.google.com/p/red5/). Post new issues or wiki entries here. 
-
 The Red5 users list may be found here: https://groups.google.com/forum/#!forum/red5interest
 
 Subreddit: http://www.reddit.com/r/red5


### PR DESCRIPTION
There is no information left in Google Code, it just shows that the project has moved:

<img width="1016" alt="screen shot 2015-07-29 at 18 11 47" src="https://cloud.githubusercontent.com/assets/148989/8970002/4f23de24-361d-11e5-8fdc-95500614475c.png">
