### PR TITLE
Changed scope of connection task executors

### DIFF
--- a/src/main/server/conf/red5-core.xml
+++ b/src/main/server/conf/red5-core.xml
@@ -20,15 +20,28 @@
 	</bean>
 	
 	<!-- RTMP -->
-    <bean id="rtmpScheduler" scope="prototype" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler">
-        <property name="poolSize" value="${rtmp.scheduler.pool_size}" />  
+    <bean id="rtmpScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler">
+        <property name="poolSize" value="${rtmp.scheduler.pool_size}" />
+        <property name="daemon" value="true" />
+        <property name="waitForTasksToCompleteOnShutdown" value="true" />
+        <property name="threadNamePrefix" value="RTMPConnectionScheduler-" />
 	</bean>        
 	        
-	<bean id="messageExecutor" scope="prototype" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">  
-        <property name="corePoolSize" value="1" />  
-	    <property name="maxPoolSize" value="1" />  
-	    <property name="queueCapacity" value="${rtmp.executor.queue_capacity}" /> 
-	</bean>     
+	<bean id="messageExecutor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">  
+        <property name="corePoolSize" value="${rtmp.executor.core_pool_size}" />
+	    <property name="maxPoolSize" value="${rtmp.executor.max_pool_size}" />
+	    <property name="queueCapacity" value="${rtmp.executor.queue_capacity}" />
+        <property name="daemon" value="false" />
+        <property name="waitForTasksToCompleteOnShutdown" value="true" />
+        <property name="threadNamePrefix" value="RTMPConnectionExecutor-" />
+	</bean>
+
+    <bean id="deadlockGuardScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler">
+        <property name="poolSize" value="${rtmp.deadlockguard.sheduler.pool_size}" />
+        <property name="daemon" value="false" />
+        <property name="waitForTasksToCompleteOnShutdown" value="true" />
+        <property name="threadNamePrefix" value="DeadlockGuardScheduler-" />
+    </bean>
     
     <!-- RTMP connection manager --> 
     <bean id="rtmpConnManager" class="org.red5.server.net.rtmp.RTMPConnManager" />
@@ -101,8 +114,10 @@
         <property name="limitType" value="${rtmp.client_bandwidth_limit_type}" />
         <!-- Bandwidth detection. If "false" the server will NOT initiate a check -->
         <property name="bandwidthDetection" value="${rtmp.bandwidth_detection}" />
+        <!-- Deadlock guard executor -->
+        <property name="deadlockGuardScheduler" ref="deadlockGuardScheduler" />
         <!-- Maximum time allowed for a single RTMP packet to be processed -->
-        <property name="maxHandlingTimeout" value="${rtmp.max_handling_time}" />
+        <property name="maxHandlingTimeout" value="${rtmp.deadlockguard.max_handling_time}" />
         <!-- Specify the size of queue that will trigger audio packet dropping, disabled if it's 0 -->
          <property name="executorQueueSizeToDropAudioPackets" value="${rtmp.executor.queue_size_to_drop_audio_packets}" />
 	</bean>
@@ -144,8 +159,10 @@
 		<property name="maxQueueOfferTime" value="${rtmpt.max_queue_offer_time}" />
 		<!-- Maximum offer attempts before failing on incoming or outgoing queues -->
 		<property name="maxQueueOfferAttempts" value="${rtmpt.max_queue_offer_attempts}" />
+        <!-- Deadlock guard executor -->
+        <property name="deadlockGuardScheduler" ref="deadlockGuardScheduler" />
 		<!-- Maximum time allowed for a single RTMP packet to be processed -->
-        <property name="maxHandlingTimeout" value="${rtmp.max_handling_time}" />
+        <property name="maxHandlingTimeout" value="${rtmp.deadlockguard.max_handling_time}" />
         <!-- Specify the size of queue that will trigger audio packet dropping, disabled if it's 0 -->
          <property name="executorQueueSizeToDropAudioPackets" value="${rtmp.executor.queue_size_to_drop_audio_packets}" />
 	</bean>

--- a/src/main/server/conf/red5.properties
+++ b/src/main/server/conf/red5.properties
@@ -44,14 +44,18 @@ rtmp.max_pool_size=2
 rtmp.max_processor_pool_size=16
 rtmp.executor_keepalive_time=60000
 mina.logfilter.enable=false
-# scheduler configs (per connection)
-rtmp.scheduler.pool_size=2
+# scheduler configs (per application)
+rtmp.scheduler.pool_size=16
+# message executor configs (per application)
 # adjust this as needed if you get tasks rejected
+rtmp.executor.core_pool_size=4
+rtmp.executor.max_pool_size=32
 rtmp.executor.queue_capacity=64
 # drop audio packets when queue is almost full, to disable this, set to 0
 rtmp.executor.queue_size_to_drop_audio_packets=60
-# maximum amount of time allotted to process a single rtmp message / packet in milliseconds, set it as 0 to disable timeout
-rtmp.max_handling_time=1000
+# deadlock guard configs
+rtmp.deadlockguard.sheduler.pool_size=32
+rtmp.deadlockguard.max_handling_time=1000
 
 # RTMPS
 rtmps.host=0.0.0.0


### PR DESCRIPTION
Current red5 version uses too many threads and consequently too much memory. As I know it is not very good to use one thread per connection, because the growth in the number of connections leads to out of memory exception and application crash.

So I offer you to return to old decision which have few thread pools per application instead of few thread pools per connection.

This pull request can be merged to master only with "Changed scope of connection task executors" pull request in red5-server-common project.