### PR TITLE
Fixing squid:S2583: Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/src/main/java/org/red5/server/net/proxy/DebugProxyHandler.java
+++ b/src/main/java/org/red5/server/net/proxy/DebugProxyHandler.java
@@ -115,20 +115,18 @@ public class DebugProxyHandler extends IoHandlerAdapter implements ResourceLoade
 
         session.getFilterChain().addFirst("proxy", new ProxyFilter(isClient ? "client" : "server"));
 
-        if (true) {
+        String fileName = System.currentTimeMillis() + '_' + forward.getHostName() + '_' + forward.getPort() + '_' + (isClient ? "DOWNSTREAM" : "UPSTREAM");
 
-            String fileName = System.currentTimeMillis() + '_' + forward.getHostName() + '_' + forward.getPort() + '_' + (isClient ? "DOWNSTREAM" : "UPSTREAM");
+        File headersFile = loader.getResource(dumpTo + fileName + ".cap").getFile();
+        headersFile.createNewFile();
 
-            File headersFile = loader.getResource(dumpTo + fileName + ".cap").getFile();
-            headersFile.createNewFile();
+        File rawFile = loader.getResource(dumpTo + fileName + ".raw").getFile();
+        rawFile.createNewFile();
 
-            File rawFile = loader.getResource(dumpTo + fileName + ".raw").getFile();
-            rawFile.createNewFile();
-
-            FileOutputStream headersFos = new FileOutputStream(headersFile);
+        FileOutputStream headersFos = new FileOutputStream(headersFile);
+        FileOutputStream rawFos = new FileOutputStream(rawFile);
+        try {
             WritableByteChannel headers = headersFos.getChannel();
-
-            FileOutputStream rawFos = new FileOutputStream(rawFile);
             WritableByteChannel raw = rawFos.getChannel();
 
             IoBuffer header = IoBuffer.allocate(1);
@@ -137,6 +135,9 @@ public class DebugProxyHandler extends IoHandlerAdapter implements ResourceLoade
             headers.write(header.buf());
 
             session.getFilterChain().addFirst("dump", new NetworkDumpFilter(headers, raw));
+        } finally {
+            headersFos.close();
+            rawFos.close();
         }
 
         //session.getFilterChain().addLast("logger", new LoggingFilter() );

--- a/src/main/java/org/red5/server/net/proxy/DebugProxyHandler.java
+++ b/src/main/java/org/red5/server/net/proxy/DebugProxyHandler.java
@@ -123,9 +123,8 @@ public class DebugProxyHandler extends IoHandlerAdapter implements ResourceLoade
         File rawFile = loader.getResource(dumpTo + fileName + ".raw").getFile();
         rawFile.createNewFile();
 
-        FileOutputStream headersFos = new FileOutputStream(headersFile);
-        FileOutputStream rawFos = new FileOutputStream(rawFile);
-        try {
+        try (FileOutputStream headersFos = new FileOutputStream(headersFile);
+             FileOutputStream rawFos = new FileOutputStream(rawFile)) {
             WritableByteChannel headers = headersFos.getChannel();
             WritableByteChannel raw = rawFos.getChannel();
 

--- a/src/main/java/org/red5/server/persistence/FilePersistence.java
+++ b/src/main/java/org/red5/server/persistence/FilePersistence.java
@@ -380,7 +380,6 @@ public class FilePersistence extends RamPersistence {
             }
             filename = fp.getAbsolutePath();
             input = new FileInputStream(filename);
-            input.close();
         } catch (FileNotFoundException e) {
             log.error("The file at {} does not exist", data.getFilename());
             return null;

--- a/src/main/java/org/red5/server/persistence/FilePersistence.java
+++ b/src/main/java/org/red5/server/persistence/FilePersistence.java
@@ -380,6 +380,7 @@ public class FilePersistence extends RamPersistence {
             }
             filename = fp.getAbsolutePath();
             input = new FileInputStream(filename);
+            input.close();
         } catch (FileNotFoundException e) {
             log.error("The file at {} does not exist", data.getFilename());
             return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2583: Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Aris Samaras