### PR TITLE
Fixing squid:S2275: Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/src/main/java/org/red5/logging/ContextLoggingListener.java
+++ b/src/main/java/org/red5/logging/ContextLoggingListener.java
@@ -59,7 +59,7 @@ public class ContextLoggingListener implements ServletContextListener {
     public void contextInitialized(ServletContextEvent event) {
         System.out.println("Context init...");
         String contextName = pathToName(event);
-        System.out.printf("Logger name for context: %s\n", contextName);
+        System.out.printf("Logger name for context: %s%n", contextName);
         LoggingContextSelector selector = null;
         try {
             selector = (LoggingContextSelector) Red5LoggerFactory.getContextSelector();
@@ -73,7 +73,7 @@ public class ContextLoggingListener implements ServletContextListener {
                 System.err.printf("No context named %s was found", contextName);
             }
         } catch (Exception e) {
-            System.err.printf("LoggingContextSelector is not the correct type", e);
+            System.err.printf("LoggingContextSelector is not the correct type: %s", e.getMessage());
         } finally {
             //reset the name
             if (selector != null) {

--- a/src/main/java/org/red5/logging/LoggingContextSelector.java
+++ b/src/main/java/org/red5/logging/LoggingContextSelector.java
@@ -105,7 +105,7 @@ public class LoggingContextSelector implements ContextSelector {
                         contextConfigFile = String.format(overrideProperty, contextName);
                     }
                     if (debug) {
-                        System.out.printf("Context logger config file: %s\n", contextConfigFile);
+                        System.out.printf("Context logger config file: %s%n", contextConfigFile);
                     }
                     ClassLoader classloader = Thread.currentThread().getContextClassLoader();
                     //System.out.printf("Thread context cl: %s\n", classloader);
@@ -131,7 +131,7 @@ public class LoggingContextSelector implements ContextSelector {
                         }
                     }
                     if (debug) {
-                        System.out.printf("Adding logger context: %s to map for context: %s\n", loggerContext.getName(), contextName);
+                        System.out.printf("Adding logger context: %s to map for context: %s%n", loggerContext.getName(), contextName);
                     }
                     contextMap.put(contextName, loggerContext);
                 }
@@ -146,7 +146,7 @@ public class LoggingContextSelector implements ContextSelector {
 
     public LoggerContext getLoggerContext(String name) {
         if (debug) {
-            System.out.printf("getLoggerContext request for %s in context map %s\n", name, contextMap.containsKey(name));
+            System.out.printf("getLoggerContext request for %s in context map %s%n", name, contextMap.containsKey(name));
         }
         return contextMap.get(name);
     }

--- a/src/main/java/org/red5/server/Launcher.java
+++ b/src/main/java/org/red5/server/Launcher.java
@@ -48,7 +48,7 @@ public class Launcher {
      *             on error
      */
     public void launch() throws Exception {
-        System.out.printf("Root: %s\nDeploy type: %s\nLogback selector: %s\n", System.getProperty("red5.root"), System.getProperty("red5.deployment.type"), System.getProperty("logback.ContextSelector"));
+        System.out.printf("Root: %s%nDeploy type: %s%nLogback selector: %s%n", System.getProperty("red5.root"), System.getProperty("red5.deployment.type"), System.getProperty("logback.ContextSelector"));
         // install the slf4j bridge (mostly for JUL logging)
         SLF4JBridgeHandler.install();
         // log stdout and stderr to slf4j


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275: Printf-style format strings should not lead to unexpected behavior at runtime
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275
Please let me know if you have any questions.
Aris Samaras