### PR TITLE
squid:S2065 - Fields in non-serializable classes should not be "transient"

### DIFF
--- a/src/main/java/org/red5/server/net/rtmpt/BaseRTMPTConnection.java
+++ b/src/main/java/org/red5/server/net/rtmpt/BaseRTMPTConnection.java
@@ -52,12 +52,12 @@ public abstract class BaseRTMPTConnection extends RTMPConnection {
     /**
      * Protocol decoder
      */
-    private transient RTMPTProtocolDecoder decoder;
+    private RTMPTProtocolDecoder decoder;
 
     /**
      * Protocol encoder
      */
-    private transient RTMPTProtocolEncoder encoder;
+    private RTMPTProtocolEncoder encoder;
 
     /**
      * Closing flag
@@ -82,7 +82,7 @@ public abstract class BaseRTMPTConnection extends RTMPConnection {
     /**
      * List of pending outgoing messages. Default size is 8192.
      */
-    protected transient volatile LinkedBlockingQueue<PendingData> pendingOutMessages = new LinkedBlockingQueue<PendingData>(8192);
+    protected volatile LinkedBlockingQueue<PendingData> pendingOutMessages = new LinkedBlockingQueue<PendingData>(8192);
 
     /**
      * Maximum incoming messages to process at a time per client

--- a/src/main/java/org/red5/server/net/rtmpt/RTMPTConnection.java
+++ b/src/main/java/org/red5/server/net/rtmpt/RTMPTConnection.java
@@ -72,7 +72,7 @@ public class RTMPTConnection extends BaseRTMPTConnection {
     /**
      * Servlet that created this connection.
      */
-    private transient RTMPTServlet servlet;
+    private RTMPTServlet servlet;
 
     /**
      * Timestamp of last data received on the connection
@@ -83,7 +83,7 @@ public class RTMPTConnection extends BaseRTMPTConnection {
 
     private AtomicLong lastBytesWritten = new AtomicLong(0);
 
-    private transient IoSession ioSession;
+    private IoSession ioSession;
 
     /** Constructs a new RTMPTConnection */
     RTMPTConnection() {

--- a/src/main/java/org/red5/server/scope/BroadcastScope.java
+++ b/src/main/java/org/red5/server/scope/BroadcastScope.java
@@ -44,12 +44,12 @@ public class BroadcastScope extends BasicScope implements IBroadcastScope, IPipe
     /**
      * Broadcasting stream associated with this scope
      */
-    private transient IClientBroadcastStream clientBroadcastStream;
+    private IClientBroadcastStream clientBroadcastStream;
 
     /**
      * Simple in memory push pipe, triggered by an active provider to push messages to consumer
      */
-    private final transient InMemoryPushPushPipe pipe;
+    private final InMemoryPushPushPipe pipe;
 
     /**
      * Number of components.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2065 - Fields in non-serializable classes should not be "transient".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2065
Please let me know if you have any questions.
George Kankava