### PR TITLE
squid:S1185 - Overriding methods should do more than simply call the same method in the super class

### DIFF
--- a/src/main/java/org/red5/server/net/rtmpt/RTMPTConnection.java
+++ b/src/main/java/org/red5/server/net/rtmpt/RTMPTConnection.java
@@ -206,12 +206,6 @@ public class RTMPTConnection extends BaseRTMPTConnection {
         this.remotePort = remotePort;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void setScheduler(ThreadPoolTaskScheduler scheduler) {
-        super.setScheduler(scheduler);
-    }
-
     /**
      * Set the servlet that created the connection.
      * 

--- a/src/main/java/org/red5/spring/Red5ApplicationContext.java
+++ b/src/main/java/org/red5/spring/Red5ApplicationContext.java
@@ -43,11 +43,6 @@ public class Red5ApplicationContext extends FileSystemXmlApplicationContext impl
     }
 
     @Override
-    public void setConfigLocation(String location) {
-        super.setConfigLocation(location);
-    }
-
-    @Override
     public void setParent(ApplicationContext parent) {
         super.setParent(parent);
         parentContext = parent;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1185 - Overriding methods should do more than simply call the same method in the super class.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1185
Please let me know if you have any questions.
George Kankava