### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/org/red5/logging/DerbyLogInterceptor.java
+++ b/src/main/java/org/red5/logging/DerbyLogInterceptor.java
@@ -28,7 +28,7 @@ public class DerbyLogInterceptor {
 
     protected static Logger log = LoggerFactory.getLogger(DerbyLogInterceptor.class);
 
-    private static ThreadLocal<StringBuilder> local = new ThreadLocal<StringBuilder>();
+    private static ThreadLocal<StringBuilder> local = new ThreadLocal<>();
 
     public static OutputStream handleDerbyLogFile() {
         return new OutputStream() {

--- a/src/main/java/org/red5/logging/LoggingContextSelector.java
+++ b/src/main/java/org/red5/logging/LoggingContextSelector.java
@@ -44,11 +44,11 @@ public class LoggingContextSelector implements ContextSelector {
 
     private static boolean debug = false;
 
-    private static final ConcurrentMap<String, LoggerContext> contextMap = new ConcurrentHashMap<String, LoggerContext>(6, 0.9f, 1);
+    private static final ConcurrentMap<String, LoggerContext> contextMap = new ConcurrentHashMap<>(6, 0.9f, 1);
 
     private static final Semaphore lock = new Semaphore(1, true);
 
-    private final ThreadLocal<LoggerContext> threadLocal = new ThreadLocal<LoggerContext>();
+    private final ThreadLocal<LoggerContext> threadLocal = new ThreadLocal<>();
 
     private final LoggerContext defaultContext;
 
@@ -164,7 +164,7 @@ public class LoggingContextSelector implements ContextSelector {
     }
 
     public List<String> getContextNames() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.addAll(contextMap.keySet());
         return list;
     }

--- a/src/main/java/org/red5/logging/W3CAppender.java
+++ b/src/main/java/org/red5/logging/W3CAppender.java
@@ -53,13 +53,13 @@ public class W3CAppender extends FileAppender<LoggingEvent> {
     private static String events;
 
     //linked list to preserve order
-    private static List<String> eventsList = new ArrayList<String>();
+    private static List<String> eventsList = new ArrayList<>();
 
     //fields that are to be logged
     private static String fields;
 
     //linked list to preserve order
-    private static LinkedList<String> fieldList = new LinkedList<String>();
+    private static LinkedList<String> fieldList = new LinkedList<>();
 
     public W3CAppender() {
         setPrudent(true);
@@ -124,7 +124,7 @@ public class W3CAppender extends FileAppender<LoggingEvent> {
         //break the message into pieces
         String[] arr = message.split(" ");
         //create a map
-        Map<String, String> elements = new HashMap<String, String>(arr.length);
+        Map<String, String> elements = new HashMap<>(arr.length);
         int i = 0;
         for (String s : arr) {
             if ((i = s.indexOf(':')) != -1) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava