### PR TITLE
duplicate inclusion of maven-jar-plugin is removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,6 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
# Pull Request

Changes proposed in this pull request:
-  Maven warning is fixed: [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-jar-plugin @ org.red5:red5-server:[unknown-version], /home/solomax/work/red5/red5-server/pom.xml, line 132, column 21
