### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/org/red5/server/stream/PlayBuffer.java
+++ b/src/main/java/org/red5/server/stream/PlayBuffer.java
@@ -45,7 +45,7 @@ public class PlayBuffer {
     /**
      * Queue of RTMP messages
      */
-    private Queue<RTMPMessage> messageQueue = new LinkedList<RTMPMessage>();
+    private Queue<RTMPMessage> messageQueue = new LinkedList<>();
 
     /**
      * Create play buffer with given capacity

--- a/src/main/java/org/red5/server/stream/ServerStream.java
+++ b/src/main/java/org/red5/server/stream/ServerStream.java
@@ -173,7 +173,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
     private RTMPMessage nextRTMPMessage;
 
     /** Listeners to get notified about received packets. */
-    private CopyOnWriteArraySet<IStreamListener> listeners = new CopyOnWriteArraySet<IStreamListener>();
+    private CopyOnWriteArraySet<IStreamListener> listeners = new CopyOnWriteArraySet<>();
 
     /**
      * Recording listener
@@ -183,7 +183,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
     /** Constructs a new ServerStream. */
     public ServerStream() {
         defaultController = new SimplePlaylistController();
-        items = new CopyOnWriteArrayList<IPlayItem>();
+        items = new CopyOnWriteArrayList<>();
     }
 
     /** {@inheritDoc} */
@@ -384,7 +384,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
                     }
                 }
                 // set as primary listener
-                recordingListener = new WeakReference<IRecordingListener>(listener);
+                recordingListener = new WeakReference<>(listener);
                 // add as a listener
                 addStreamListener(listener);
                 // start the listener thread
@@ -832,7 +832,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
             // Set service name of init
             oobCtrlMsg.setServiceName("init");
             // Create map for parameters
-            Map<String, Object> paramMap = new HashMap<String, Object>(1);
+            Map<String, Object> paramMap = new HashMap<>(1);
             // Put start timestamp into Map of params
             paramMap.put("startTS", start);
             // Attach to OOB control message and send it
@@ -853,7 +853,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
         OOBControlMessage oobCtrlMsg = new OOBControlMessage();
         oobCtrlMsg.setTarget(ISeekableProvider.KEY);
         oobCtrlMsg.setServiceName("seek");
-        Map<String, Object> paramMap = new HashMap<String, Object>(1);
+        Map<String, Object> paramMap = new HashMap<>(1);
         paramMap.put("position", Integer.valueOf(position));
         oobCtrlMsg.setServiceParamMap(paramMap);
         msgIn.sendOOBControlMessage(this, oobCtrlMsg);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava