### PR TITLE
Multiple code improvements - squid:S1171, squid:S134, squid:S1066

### DIFF
--- a/src/main/java/org/red5/server/scope/ScopeResolver.java
+++ b/src/main/java/org/red5/server/scope/ScopeResolver.java
@@ -112,10 +112,8 @@ public class ScopeResolver implements IScopeResolver {
                     throw new ScopeNotFoundException(scope, child);
                 }
                 // some scopes don't implement IScope, such as SharedObjectScope
-                if (scope instanceof IScope) {
-                    if (scope.getType().equals(ScopeType.APPLICATION) && ((WebScope) scope).isShuttingDown()) {
-                        throw new ScopeShuttingDownException(scope);
-                    }
+                if (scope instanceof IScope && scope.getType().equals(ScopeType.APPLICATION) && ((WebScope) scope).isShuttingDown()) {
+                    throw new ScopeShuttingDownException(scope);
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1171 The diamond operator ("<>") should be used.
squid:S134 Unused local variables should be removed.
squid:S1066 Unused local variables should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1171
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava