### PR TITLE
Setting the keep-alive to unlimited reduces rtmpt disconnection rates.

### DIFF
--- a/src/main/server/conf/jee-container.xml
+++ b/src/main/server/conf/jee-container.xml
@@ -32,6 +32,12 @@
                     <property name="protocol" value="org.apache.coyote.http11.Http11NioProtocol" />
                     <property name="address" value="${http.host}:${http.port}" />
                     <property name="redirectPort" value="${https.port}" />  
+                    <property name="connectionProperties">
+                        <map>
+                            <entry key="maxKeepAliveRequests" value="-1"/>
+                            <entry key="keepAliveTimout" value="-1"/>
+                        </map>
+                    </property>
                 </bean>     
             </list>
         </property>


### PR DESCRIPTION
# Pull Request

This PR fixes #199  

Changes proposed in this pull request:
-Increase maxKeepAliveRequests since this decreases the amount of disconnections when using RTMPT over a reverse proxy.



