### PR TITLE
java options clean-up

### DIFF
--- a/src/main/server/red5.sh
+++ b/src/main/server/red5.sh
@@ -37,7 +37,7 @@ echo "Running on " $OS
 # JAVA options
 # You can set JVM additional options here if you want
 if [ -z "$JVM_OPTS" ]; then 
-    JVM_OPTS="-Xms256m -Xmx1g -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=2"
+    JVM_OPTS="-Xms256m -Xmx1g -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=2"
 fi
 # Set up security options
 SECURITY_OPTS="-Djava.security.debug=failure"


### PR DESCRIPTION
`-XX:+UseParNewGC` is removed in java11
Additionally according to https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
It is automatically enabled if `-XX:+UseConcMarkSweepGC`

# Pull Request

This PR fixes #__Enter issue number__

Changes proposed in this pull request:
- 
- 
-


