### PR TITLE
java options clean-up

### DIFF
--- a/src/main/server/red5.bat
+++ b/src/main/server/red5.bat
@@ -8,7 +8,7 @@ if NOT DEFINED JAVA_HOME goto err
 
 REM JAVA options
 REM You can set JVM additional options here if you want
-if NOT DEFINED JVM_OPTS set JVM_OPTS=-Xms256m -Xmx1g -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=2
+if NOT DEFINED JVM_OPTS set JVM_OPTS=-Xms256m -Xmx1g -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=2
 REM Set up logging options
 set LOGGING_OPTS=-Dlogback.ContextSelector=org.red5.logging.LoggingContextSelector -Dcatalina.useNaming=true
 REM Set up security options


### PR DESCRIPTION
`-XX:+UseParNewGC` is removed in java11
Additionally according to https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
It is automatically enabled if `-XX:+UseConcMarkSweepGC`

# Pull Request

This PR fixes #__Enter issue number__

Changes proposed in this pull request:
- 
- 
-


