### PR TITLE
Fix liveWaitSupport bug when play a non-exist stream.

### DIFF
--- a/src/main/java/org/red5/server/stream/ProviderService.java
+++ b/src/main/java/org/red5/server/stream/ProviderService.java
@@ -218,6 +218,11 @@ public class ProviderService implements IProviderService {
                     log.debug("File {} not found, nulling it", filename);
                 }
             }
+            // check file existence
+            if (file != null && !file.exists()) {
+                // if it does not exist then null it out
+                file = null;
+            }
         } catch (IOException e) {
             log.info("Exception attempting to lookup file: {}", e.getMessage());
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fix bug when liveWaitSupport is set to true and play a stream it does not exist.

# Pull Request

This PR fixes #289 

Changes proposed in this pull request:
- src/main/java/org/red5/server/stream/ProviderService.java



