### PR TITLE
Update red5.properties

### DIFF
--- a/src/main/server/conf/red5.properties
+++ b/src/main/server/conf/red5.properties
@@ -9,9 +9,9 @@ https.port=5443
 http.URIEncoding=UTF-8
 http.max_headers_size=8192
 http.max_keep_alive_requests=-1
-http.max_threads=20
-http.acceptor_thread_count=10
-http.processor_cache=20
+http.max_threads=2000
+http.acceptor_thread_count=100
+http.processor_cache=200
 
 # RTMP
 rtmp.host=0.0.0.0


### PR DESCRIPTION
propose just making the following changes for better performance; at this point the server shouldn't be run on an instance that can't at least support these values
http.max_threads=2000
http.acceptor_thread_count=100
http.processor_cache=200

# Pull Request

This PR fixes #__Enter issue number__

Changes proposed in this pull request:
- 
- 
-


