### PR TITLE
Bug/r5 si 786

### DIFF
--- a/client/src/test/java/org/red5/client/net/rtmp/codec/RTMPClientProtocolDecoderTest.java
+++ b/client/src/test/java/org/red5/client/net/rtmp/codec/RTMPClientProtocolDecoderTest.java
@@ -90,17 +90,17 @@ public class RTMPClientProtocolDecoderTest {
         assertNotNull(packet);
         assertTrue(packet.getMessage() instanceof AudioData);
     }
-    
+
     @Test
     public void testExtendedTImestampPartialPacket() {
-    	//Buffer contains 2 complete objects and 1 incomplete object.
+        //Buffer contains 2 complete objects and 1 incomplete object.
         byte[] buf = IOUtils.hexStringToByteArray("03ffffff00004b090100000005584fce270100002800000042419e1e45152c236f0000030000030000030000030000030000030000030000030000030000030000030000030000030000030000030000030000030000030000049c03ffffff000008080100000005584fd1af01211004608c1c03ffffff000049090100000005");
         RTMPConnection conn = RTMPConnManager.getInstance().createConnection(RTMPMinaConnection.class);
         conn.setStateCode(RTMP.STATE_CONNECTED);
         RTMPClientProtocolDecoder decoder = new RTMPClientProtocolDecoder();
         List<Object> objects = decoder.decodeBuffer(conn, IoBuffer.wrap(buf));
-        //RTMPDecodeState state = conn.getDecoderState();        
+        //RTMPDecodeState state = conn.getDecoderState();
         assertTrue(objects.size() == 2);
-        
+
     }
 }

--- a/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
@@ -365,13 +365,13 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         int headerLength = RTMPUtils.getHeaderLength(headerSize);
         headerLength += chh.getSize() - 1;
         //If remaining bytes is less than known headerLength return null and set decoder state.
-        //This length does not include 4-byte extended timestamp field if present. 
-        if (in.remaining() < headerLength ) {
+        //This length does not include 4-byte extended timestamp field if present.
+        if (in.remaining() < headerLength) {
             state.bufferDecoding(headerLength - in.remaining());
             in.position(startPostion);
             return null;
-        } 
-        
+        }
+
         Header lastHeader = rtmp.getLastReadHeader(channelId);
         if (log.isTraceEnabled()) {
             log.trace("{} lastHeader: {}", Header.HeaderType.values()[headerSize], lastHeader);
@@ -406,12 +406,12 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
                 header.setStreamId(RTMPUtils.readReverseInt(in));
                 // read the extended timestamp if we have the indication that it exists
                 if (timeBase >= MEDIUM_INT_MAX) {
-                	headerLength+=4;                	
-                	if (in.remaining() < 4 ) {
+                    headerLength += 4;
+                    if (in.remaining() < 4) {
                         state.bufferDecoding(headerLength - in.remaining());
                         in.position(startPostion);
                         return null;
-                    } 
+                    }
                     long ext = in.getUnsignedInt();
                     timeBase = (int) (ext ^ (ext >>> 32));
                     if (log.isTraceEnabled()) {
@@ -432,12 +432,12 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
                 header.setStreamId(lastHeader.getStreamId());
                 // read the extended timestamp if we have the indication that it exists
                 if (timeDelta >= MEDIUM_INT_MAX) {
-                	headerLength+=4;
-                	if (in.remaining() < 4 ) {
+                    headerLength += 4;
+                    if (in.remaining() < 4) {
                         state.bufferDecoding(headerLength - in.remaining());
                         in.position(startPostion);
                         return null;
-                    } 
+                    }
                     long ext = in.getUnsignedInt();
                     timeDelta = (int) (ext ^ (ext >>> 32));
                     header.setExtended(true);
@@ -455,12 +455,12 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
                 header.setStreamId(lastHeader.getStreamId());
                 // read the extended timestamp if we have the indication that it exists
                 if (timeDelta >= MEDIUM_INT_MAX) {
-                	headerLength+=4;
-                	if (in.remaining() < 4 ) {
+                    headerLength += 4;
+                    if (in.remaining() < 4) {
                         state.bufferDecoding(headerLength - in.remaining());
                         in.position(startPostion);
                         return null;
-                    } 
+                    }
                     long ext = in.getUnsignedInt();
                     timeDelta = (int) (ext ^ (ext >>> 32));
                     header.setExtended(true);
@@ -479,8 +479,8 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
                 // This field is present in Type 3 chunks when the most recent Type 0, 1, or 2 chunk for the same chunk stream ID
                 // indicated the presence of an extended timestamp field
                 if (lastHeader.isExtended()) {
-                	headerLength+=4;
-                	if (in.remaining() < 4 ) {
+                    headerLength += 4;
+                    if (in.remaining() < 4) {
                         state.bufferDecoding(headerLength - in.remaining());
                         in.position(startPostion);
                         return null;


### PR DESCRIPTION
Fixed buffer underflow on extended timestamp field when encountering partial packet during decode. 




