### PR TITLE
Improve saveObject Method: Remove Persistence File for Empty SharedObject Instances

### DIFF
--- a/server/src/main/java/org/red5/server/persistence/FilePersistence.java
+++ b/server/src/main/java/org/red5/server/persistence/FilePersistence.java
@@ -529,14 +529,6 @@ public class FilePersistence extends RamPersistence {
         }
         //if we made it this far and everything seems ok
         if (result) {
-            // if it's a persistent SharedObject and it's empty don't write it to disk. APPSERVER-364
-            if (object instanceof SharedObject) {
-                SharedObject soRef = (SharedObject) object;
-                if (soRef.getAttributes().size() == 0) {
-                    // if SharedObject is empty, remove the persistence file to not load old data in the future
-                    return dir.delete();
-                }
-            }
             String filename = getObjectFilename(object);
             log.debug("File name: {}", filename);
             //strip path
@@ -545,6 +537,16 @@ public class FilePersistence extends RamPersistence {
                 log.debug("New file name: {}", filename);
             }
             File file = new File(dir, filename);
+
+            // if it's a persistent SharedObject and it's empty don't write it to disk. APPSERVER-364
+            if (object instanceof SharedObject) {
+                SharedObject soRef = (SharedObject) object;
+                // if SharedObject is empty and have a persistence file
+                if (soRef.getAttributes().isEmpty() && file.exists()) {
+                    // remove the persistence file to not load old data in the future
+                    return file.delete();
+                }
+            }
             //Resource resFile = resources.getResource(filename);
             //log.debug("Resource (file) check #1 - file name: {} exists: {}", resPath.getFilename(), exists);
             IoBuffer buf = null;

--- a/server/src/main/java/org/red5/server/persistence/FilePersistence.java
+++ b/server/src/main/java/org/red5/server/persistence/FilePersistence.java
@@ -533,8 +533,8 @@ public class FilePersistence extends RamPersistence {
             if (object instanceof SharedObject) {
                 SharedObject soRef = (SharedObject) object;
                 if (soRef.getAttributes().size() == 0) {
-                    // return true to trick the server into thinking everything is just fine :P
-                    return true;
+                    // if SharedObject is empty, remove the persistence file to not load old data in the future
+                    return dir.delete();
                 }
             }
             String filename = getObjectFilename(object);


### PR DESCRIPTION
# Pull Request

This pull request improves the `saveObject` method in the `FilePersistence.java` file by adding a check for empty `SharedObject` instances. If a `SharedObject` is empty (i.e., it has no attributes), the corresponding persistence file is now deleted. This prevents the server from loading outdated or unnecessary data in the future.

