### PR TITLE
Fixed buffer underflow.

### DIFF
--- a/io/src/main/java/org/red5/codec/HEVCVideo.java
+++ b/io/src/main/java/org/red5/codec/HEVCVideo.java
@@ -10,6 +10,8 @@ package org.red5.codec;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.mina.core.buffer.IoBuffer;
+import org.red5.io.IoConstants;
+import org.red5.util.ByteNibbler;
 
 /**
  * Red5 video codec for the HEVC (h265) video format. Stores DecoderConfigurationRecord and last keyframe.
@@ -213,15 +215,15 @@ public class HEVCVideo extends AbstractVideo implements IEnhancedRTMPVideoCodec 
     //                // reset back to the beginning after we got the fourcc
     //                data.reset();
     //                VideoCodec frameCodec = VideoCodec.valueOfByFourCc(fourcc);
-    //                if(frameCodec!= codec) {
-    //                	return false;
+    //                if (frameCodec != codec) {
+    //                    return false;
     //                }
     //
     //                if (isDebug) {
-    //                    log.debug("{} - frame type: {} packet type: {}",frameCodec, frameType, packetType);
+    //                    log.debug("{} - frame type: {} packet type: {}", frameCodec, frameType, packetType);
     //                }
     //                if (packetType != VideoPacketType.Metadata && frameType == VideoFrameType.COMMAND_FRAME) {
-    //                	return true;
+    //                    return true;
     //                }
     //                //Multitrack support not implemented for HEVC yet.
     //                //Abstract video should call abstract methods from it's 'Add data' method for handling the payload types it parses.
@@ -301,8 +303,8 @@ public class HEVCVideo extends AbstractVideo implements IEnhancedRTMPVideoCodec 
     //                byte hvcType = data.get();
     //                // reset back to the beginning after we got the hvc type
     //                data.reset();
-    //                if((hvcType & 0x0f) != VideoCodec.HEVC.getId()) {
-    //                	return false;
+    //                if ((hvcType & 0x0f) != VideoCodec.HEVC.getId()) {
+    //                    return false;
     //                }
     //                if (isDebug) {
     //                    log.debug("HEVC type: {}", hvcType);

--- a/io/src/test/java/org/red5/codec/AVCVideoTest.java
+++ b/io/src/test/java/org/red5/codec/AVCVideoTest.java
@@ -34,12 +34,16 @@ public class AVCVideoTest {
     @Test
     public void testCanHandleData() {
         log.info("testCanHandleData");
-        IoBuffer data = IoBuffer.allocate(8);
+        IoBuffer data = IoBuffer.allocate(9);
         data.put((byte) 0x17);
+        data.putInt(0);
+        data.putInt(0);
         data.flip();
         //
-        IoBuffer badData = IoBuffer.allocate(8);
+        IoBuffer badData = IoBuffer.allocate(9);
         badData.put((byte) 0x44);
+        badData.putInt(0);
+        badData.putInt(0);
         badData.flip();
 
         AVCVideo video = new AVCVideo();

--- a/io/src/test/java/org/red5/codec/HEVCVideoTest.java
+++ b/io/src/test/java/org/red5/codec/HEVCVideoTest.java
@@ -65,8 +65,10 @@ public class HEVCVideoTest {
     @Test
     public void testCanHandleData() {
         log.info("testCanHandleData");
-        IoBuffer data = IoBuffer.allocate(8);
+        IoBuffer data = IoBuffer.allocate(9);
         data.put((byte) 0x1c);
+        data.putInt(0);
+        data.putInt(0);
         data.flip();
         //
         IoBuffer badData = IoBuffer.allocate(8);
@@ -84,12 +86,17 @@ public class HEVCVideoTest {
     @Test
     public void testCanHandleDataEnhanced() {
         log.info("testCanHandleDataEnhanced");
-        IoBuffer data = IoBuffer.allocate(8);
+        IoBuffer data = IoBuffer.allocate(9);
         // first bit being set indicates enhanced
         byte enhancedByte = (byte) 0b10011100;
-        log.info("enhancedByte: {}", Integer.toHexString(enhancedByte));
+        log.info("enhancedByte: {}", Integer.toHexString(enhancedByte & 0xFF));
         //data.put(enhancedByte);
         data.put((byte) 0x9c);
+        data.put((byte) 'h');
+        data.put((byte) 'v');
+        data.put((byte) 'c');
+        data.put((byte) '1');
+        data.putInt(0);
         data.flip();
 
         HEVCVideo video = new HEVCVideo();


### PR DESCRIPTION
# Pull Request

This PR fixes buffer underflow / decapitated data when using abstract codec parse method. 

Updates canHandle and junits for avc and hevc


