### PR TITLE
Add hook to disable web socket permessage deflate.

### DIFF
--- a/server/src/main/java/org/red5/net/websocket/server/UpgradeUtil.java
+++ b/server/src/main/java/org/red5/net/websocket/server/UpgradeUtil.java
@@ -45,6 +45,8 @@ public class UpgradeUtil {
 
     private static final byte[] WS_ACCEPT = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".getBytes(StandardCharsets.ISO_8859_1);
 
+    public static boolean wsAllowCompression = true;
+
     private UpgradeUtil() {
         // Utility class. Hide default constructor.
     }
@@ -121,12 +123,13 @@ public class UpgradeUtil {
         }
         // Negotiation phase 1. By default this simply filters out the extensions that the server does not support but applications could
         // use a custom configurator to do more than this.
-        List<Extension> installedExtensions = null;
-        if (sec.getExtensions().size() == 0) {
-            installedExtensions = Constants.INSTALLED_EXTENSIONS;
-        } else {
-            installedExtensions = new ArrayList<>();
-            installedExtensions.addAll(sec.getExtensions());
+        List<Extension> installedExtensions = new ArrayList<>();
+
+        if (sec.getExtensions().size() > 0) {
+        	installedExtensions.addAll(sec.getExtensions());
+        }
+        // Enable permessage-deflate negotiation.  
+        if (wsAllowCompression ) {
             installedExtensions.addAll(Constants.INSTALLED_EXTENSIONS);
         }
         List<Extension> negotiatedExtensionsPhase1 = sec.getConfigurator().getNegotiatedExtensions(installedExtensions, extensionsRequested);

--- a/server/src/main/java/org/red5/server/tomcat/TomcatLoader.java
+++ b/server/src/main/java/org/red5/server/tomcat/TomcatLoader.java
@@ -40,6 +40,7 @@ import org.apache.catalina.realm.JAASRealm;
 import org.apache.catalina.realm.NullRealm;
 import org.apache.catalina.realm.RealmBase;
 import org.red5.net.websocket.WebSocketPlugin;
+import org.red5.net.websocket.server.UpgradeUtil;
 import org.red5.server.ContextLoader;
 import org.red5.server.LoaderBase;
 import org.red5.server.Server;
@@ -355,6 +356,10 @@ public class TomcatLoader extends LoaderBase implements InitializingBean, Dispos
             // Use default webapps directory
             webappFolder = FileUtil.formatPath(serverRoot, "/webapps");
         }
+        
+        // To negotiate for web-socket compression or not. 
+        UpgradeUtil.wsAllowCompression = Boolean.valueOf(System.getProperty("ws.allow.compression", "true")); 
+        
         System.setProperty("red5.webapp.root", webappFolder);
         log.info("Application root: {}", webappFolder);
         // Root applications directory


### PR DESCRIPTION
# Pull Request

ability to disable websocket compression.

Changes proposed in this pull request: new system property to read at startup that prevents per-message-deflate from web socket response. 