### PR TITLE
OSRS-15 update for attribute store concurrency and clean up

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-client</artifactId>

--- a/client/src/main/java/org/red5/client/Red5Client.java
+++ b/client/src/main/java/org/red5/client/Red5Client.java
@@ -18,7 +18,7 @@ public final class Red5Client {
     /**
      * Current server version with revision
      */
-    public static final String VERSION = "Red5 Client 2.0.19";
+    public static final String VERSION = "Red5 Client 2.0.20";
 
     /**
      * Create a new Red5Client object using the connection local to the current thread A bit of magic that lets you access the red5 scope

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-server-common</artifactId>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>net.engio</groupId>
             <artifactId>mbassador</artifactId>
-            <version>2.0.19</version>
+            <version>2.0.20</version>
         </dependency> -->
     </dependencies>
 </project>

--- a/common/src/main/java/org/red5/server/AttributeStore.java
+++ b/common/src/main/java/org/red5/server/AttributeStore.java
@@ -236,6 +236,18 @@ public class AttributeStore implements ICastingAttributeStore {
 
     /**
      * {@inheritDoc}
+     */
+    public Object setAttributeIfAbsent(final String name, final Object value) {
+        log.trace("setAttributeIfAbsent({}, {})", name, value);
+        if (name == null || value == null) {
+            return null;
+        }
+        // putIfAbsent returns the previous value or null if it was absent
+        return attributes.putIfAbsent(name, value);
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @param values a {@link java.util.Map} object
      * @return a boolean

--- a/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
+++ b/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
@@ -153,6 +153,7 @@ public abstract class AbstractScopeAdapter implements IScopeAware, IScopeHandler
      *
      * @return Wrapped scope
      */
+    @Override
     public IScope getScope() {
         return scope;
     }

--- a/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
+++ b/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
@@ -7,14 +7,19 @@
 
 package org.red5.server.adapter;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.red5.server.api.IAttributeStore;
+import org.red5.server.api.ICastingAttributeStore;
 import org.red5.server.api.IClient;
 import org.red5.server.api.IConnection;
 import org.red5.server.api.Red5;
 import org.red5.server.api.event.IEvent;
 import org.red5.server.api.scope.IBasicScope;
 import org.red5.server.api.scope.IScope;
+import org.red5.server.api.scope.IScopeAware;
 import org.red5.server.api.scope.IScopeHandler;
 import org.red5.server.api.service.IServiceCall;
 
@@ -23,9 +28,12 @@ import org.red5.server.api.service.IServiceCall;
  *
  * @author mondain
  */
-public abstract class AbstractScopeAdapter implements IScopeHandler {
+public abstract class AbstractScopeAdapter implements IScopeAware, IScopeHandler, ICastingAttributeStore {
 
-    //private static Logger log = LoggerFactory.getLogger(AbstractScopeAdapter.class);
+    /**
+     * Wrapped scope
+     */
+    protected volatile IScope scope;
 
     /**
      * Can start flag.
@@ -128,6 +136,25 @@ public abstract class AbstractScopeAdapter implements IScopeHandler {
      * otherwise
      */
     private boolean canHandleEvent = true;
+
+    /**
+     * Setter for wrapped scope
+     *
+     * @param scope
+     *            Scope to wrap
+     */
+    public void setScope(IScope scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Getter for wrapped scope
+     *
+     * @return Wrapped scope
+     */
+    public IScope getScope() {
+        return scope;
+    }
 
     /**
      * Setter for can start flag.
@@ -297,11 +324,186 @@ public abstract class AbstractScopeAdapter implements IScopeHandler {
         return null;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public Object getAttribute(String name) {
+        return scope.getAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object getAttribute(Enum<?> enm) {
+        return getAttribute(enm.name());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object getAttribute(String name, Object defaultValue) {
+        Object value = scope.getAttribute(name);
+        if (value == null) {
+            value = defaultValue;
+        }
+        return value;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getAttributeNames() {
+        return scope.getAttributeNames();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, Object> getAttributes() {
+        return scope.getAttributes();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasAttribute(String name) {
+        return scope.hasAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasAttribute(Enum<?> enm) {
+        return hasAttribute(enm.name());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean removeAttribute(String name) {
+        return scope.removeAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean removeAttribute(Enum<?> enm) {
+        return removeAttribute(enm.name());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void removeAttributes() {
+        Set<String> names = scope.getAttributeNames();
+        for (String name : names) {
+            scope.removeAttribute(name);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean setAttribute(String name, Object value) {
+        return scope.setAttribute(name, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean setAttribute(Enum<?> enm, Object value) {
+        return setAttribute(enm.name(), value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean setAttributes(IAttributeStore attributes) {
+        int successes = 0;
+        for (Map.Entry<String, Object> entry : attributes.getAttributes().entrySet()) {
+            if (scope.setAttribute(entry.getKey(), entry.getValue())) {
+                successes++;
+            }
+        }
+        // expect every value to have been added
+        return (successes == attributes.size());
+    }
+
     /**
-     * <p>getScope.</p>
+     * {@inheritDoc}
      *
-     * @return a {@link org.red5.server.api.scope.IScope} object
+     * @param attributes a {@link java.util.Map} object
+     * @return a boolean
      */
-    public abstract IScope getScope();
+    @Override
+    public boolean setAttributes(Map<String, Object> attributes) {
+        int successes = 0;
+        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+            if (scope.setAttribute(entry.getKey(), entry.getValue())) {
+                successes++;
+            }
+        }
+        // expect every value to have been added
+        return (successes == attributes.size());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object setAttributeIfAbsent(String name, Object value) {
+        return scope.setAttributeIfAbsent(name, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Boolean getBoolAttribute(String name) {
+        return scope.getBoolAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Byte getByteAttribute(String name) {
+        return scope.getByteAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Double getDoubleAttribute(String name) {
+        return scope.getDoubleAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Integer getIntAttribute(String name) {
+        return scope.getIntAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<?> getListAttribute(String name) {
+        return scope.getListAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Long getLongAttribute(String name) {
+        return scope.getLongAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<?, ?> getMapAttribute(String name) {
+        return scope.getMapAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<?> getSetAttribute(String name) {
+        return scope.getSetAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Short getShortAttribute(String name) {
+        return scope.getShortAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getStringAttribute(String name) {
+        return scope.getStringAttribute(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int size() {
+        return scope != null ? scope.getAttributeNames().size() : 0;
+    }
 
 }

--- a/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
+++ b/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
@@ -387,10 +387,7 @@ public abstract class AbstractScopeAdapter implements IScopeAware, IScopeHandler
     /** {@inheritDoc} */
     @Override
     public void removeAttributes() {
-        Set<String> names = scope.getAttributeNames();
-        for (String name : names) {
-            scope.removeAttribute(name);
-        }
+        scope.removeAttributes();
     }
 
     /** {@inheritDoc} */

--- a/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
+++ b/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
@@ -341,9 +341,12 @@ public abstract class AbstractScopeAdapter implements IScopeAware, IScopeHandler
     /** {@inheritDoc} */
     @Override
     public Object getAttribute(String name, Object defaultValue) {
-        Object value = scope.getAttribute(name);
+        // this sets the attribute if it does not exist and returns the default value
+        // if it already existed, the existing value is returned
+        Object value = scope.setAttributeIfAbsent(name, defaultValue);
         if (value == null) {
-            value = defaultValue;
+            // if the value was not set, return the default value
+            return defaultValue;
         }
         return value;
     }

--- a/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
+++ b/common/src/main/java/org/red5/server/adapter/AbstractScopeAdapter.java
@@ -143,6 +143,7 @@ public abstract class AbstractScopeAdapter implements IScopeAware, IScopeHandler
      * @param scope
      *            Scope to wrap
      */
+    @Override
     public void setScope(IScope scope) {
         this.scope = scope;
     }

--- a/common/src/main/java/org/red5/server/api/IAttributeStore.java
+++ b/common/src/main/java/org/red5/server/api/IAttributeStore.java
@@ -57,6 +57,17 @@ public interface IAttributeStore extends AttributeStoreMXBean {
     boolean setAttribute(final Enum<?> enm, final Object value);
 
     /**
+     * Set an attribute on this object if it is not already set.
+     *
+     * @param name
+     *            the name of the attribute
+     * @param value
+     *            the value of the attribute
+     * @return previous value or null if it was absent
+     */
+    Object setAttributeIfAbsent(final String name, final Object value);
+
+    /**
      * Set multiple attributes on this object.
      *
      * @param values

--- a/common/src/main/java/org/red5/server/api/IAttributeStore.java
+++ b/common/src/main/java/org/red5/server/api/IAttributeStore.java
@@ -25,14 +25,14 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *
      * @return set containing all attribute names
      */
-    public Set<String> getAttributeNames();
+    Set<String> getAttributeNames();
 
     /**
      * Get the attributes. The resulting map will be read-only.
      *
      * @return map containing all attributes
      */
-    public Map<String, Object> getAttributes();
+    Map<String, Object> getAttributes();
 
     /**
      * Set an attribute on this object.
@@ -43,7 +43,7 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *            the new value of the attribute
      * @return true if the attribute value changed otherwise false
      */
-    public boolean setAttribute(String name, Object value);
+    boolean setAttribute(String name, Object value);
 
     /**
      * Set an attribute on this object.
@@ -74,7 +74,7 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *            the attributes to set
      * @return true if the attribute values changed otherwise false
      */
-    public boolean setAttributes(Map<String, Object> values);
+    boolean setAttributes(Map<String, Object> values);
 
     /**
      * Set multiple attributes on this object.
@@ -83,7 +83,7 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *            the attributes to set
      * @return true if the attribute values changed otherwise false
      */
-    public boolean setAttributes(IAttributeStore values);
+    boolean setAttributes(IAttributeStore values);
 
     /**
      * Return the value for a given attribute.
@@ -92,7 +92,7 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *            the name of the attribute to get
      * @return the attribute value or null if the attribute doesn't exist
      */
-    public Object getAttribute(String name);
+    Object getAttribute(String name);
 
     /**
      * Return the value for a given attribute.
@@ -120,14 +120,14 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *            the value of the attribute to set if the attribute doesn't exist
      * @return the attribute value
      */
-    public Object getAttribute(String name, Object defaultValue);
+    Object getAttribute(String name, Object defaultValue);
 
     /**
      * {@inheritDoc}
      *
      * Check the object has an attribute.
      */
-    public boolean hasAttribute(String name);
+    boolean hasAttribute(String name);
 
     /**
      * Check the object has an attribute.
@@ -143,7 +143,7 @@ public interface IAttributeStore extends AttributeStoreMXBean {
      *
      * Remove an attribute.
      */
-    public boolean removeAttribute(String name);
+    boolean removeAttribute(String name);
 
     /**
      * Remove an attribute.
@@ -157,13 +157,13 @@ public interface IAttributeStore extends AttributeStoreMXBean {
     /**
      * Remove all attributes.
      */
-    public void removeAttributes();
+    void removeAttributes();
 
     /**
      * Size of the attribute store.
      *
      * @return count of attributes
      */
-    public int size();
+    int size();
 
 }

--- a/common/src/main/java/org/red5/server/api/ICastingAttributeStore.java
+++ b/common/src/main/java/org/red5/server/api/ICastingAttributeStore.java
@@ -26,7 +26,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Boolean getBoolAttribute(String name);
+    Boolean getBoolAttribute(String name);
 
     /**
      * Get Byte attribute by name
@@ -35,7 +35,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Byte getByteAttribute(String name);
+    Byte getByteAttribute(String name);
 
     /**
      * Get Double attribute by name
@@ -44,7 +44,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Double getDoubleAttribute(String name);
+    Double getDoubleAttribute(String name);
 
     /**
      * Get Integer attribute by name
@@ -53,7 +53,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Integer getIntAttribute(String name);
+    Integer getIntAttribute(String name);
 
     /**
      * Get List attribute by name
@@ -62,7 +62,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public List<?> getListAttribute(String name);
+    List<?> getListAttribute(String name);
 
     /**
      * Get boolean attribute by name
@@ -71,7 +71,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Long getLongAttribute(String name);
+    Long getLongAttribute(String name);
 
     /**
      * Get Long attribute by name
@@ -80,7 +80,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Map<?, ?> getMapAttribute(String name);
+    Map<?, ?> getMapAttribute(String name);
 
     /**
      * Get Set attribute by name
@@ -89,7 +89,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Set<?> getSetAttribute(String name);
+    Set<?> getSetAttribute(String name);
 
     /**
      * Get Short attribute by name
@@ -98,7 +98,7 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public Short getShortAttribute(String name);
+    Short getShortAttribute(String name);
 
     /**
      * Get String attribute by name
@@ -107,5 +107,6 @@ public interface ICastingAttributeStore extends IAttributeStore {
      *            Attribute name
      * @return Attribute
      */
-    public String getStringAttribute(String name);
+    String getStringAttribute(String name);
+
 }

--- a/common/src/main/java/org/red5/server/api/Red5.java
+++ b/common/src/main/java/org/red5/server/api/Red5.java
@@ -57,12 +57,12 @@ public final class Red5 {
     /**
      * Server version with revision
      */
-    public static final String VERSION = "Red5 Server 2.0.19";
+    public static final String VERSION = "Red5 Server 2.0.20";
 
     /**
      * Server version for fmsVer requests
      */
-    public static final String FMS_VERSION = "RED5/2,0,19,0";
+    public static final String FMS_VERSION = "RED5/2,0,20,0";
 
     /**
      * Server capabilities

--- a/common/src/main/java/org/red5/server/api/scope/IBasicScope.java
+++ b/common/src/main/java/org/red5/server/api/scope/IBasicScope.java
@@ -9,6 +9,7 @@ package org.red5.server.api.scope;
 
 import java.util.Set;
 
+import org.red5.server.api.ICastingAttributeStore;
 import org.red5.server.api.IConnection;
 import org.red5.server.api.ICoreObject;
 import org.red5.server.api.event.IEventObservable;
@@ -20,7 +21,7 @@ import org.red5.server.api.persistence.IPersistenceStore;
  * @author The Red5 Project
  * @author Luke Hubbard (luke@codegent.com)
  */
-public interface IBasicScope extends ICoreObject, IEventObservable {
+public interface IBasicScope extends ICoreObject, ICastingAttributeStore, IEventObservable {
 
     /**
      * Does this scope have a parent? You can think of scopes as of tree items where scope may have a parent and children (child).

--- a/common/src/main/java/org/red5/server/api/scope/IScopeAware.java
+++ b/common/src/main/java/org/red5/server/api/scope/IScopeAware.java
@@ -21,6 +21,15 @@ public interface IScopeAware {
      * @param scope
      *            Scope for this object
      */
-    public void setScope(IScope scope);
+    void setScope(IScope scope);
+
+    /**
+     * Get the scope the object is located in.
+     *
+     * @return Scope for this object
+     */
+    default IScope getScope() {
+        return null;
+    }
 
 }

--- a/common/src/main/java/org/red5/server/scope/BasicScope.java
+++ b/common/src/main/java/org/red5/server/scope/BasicScope.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.red5.server.AttributeStore;
 import org.red5.server.api.IConnection;
 import org.red5.server.api.event.IEvent;
 import org.red5.server.api.event.IEventListener;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @see org.red5.server.scope.Scope
  * @author mondain
  */
-public abstract class BasicScope implements IBasicScope, Comparable<BasicScope> {
+public abstract class BasicScope extends AttributeStore implements IBasicScope, Comparable<BasicScope> {
 
     /** Constant <code>log</code> */
     protected static Logger log = LoggerFactory.getLogger(BasicScope.class);

--- a/common/src/main/java/org/red5/server/scope/Scope.java
+++ b/common/src/main/java/org/red5/server/scope/Scope.java
@@ -29,7 +29,6 @@ import javax.management.StandardMBean;
 import javax.management.openmbean.CompositeData;
 
 import org.apache.commons.lang3.StringUtils;
-import org.red5.server.AttributeStore;
 import org.red5.server.Server;
 import org.red5.server.api.IClient;
 import org.red5.server.api.IConnection;
@@ -148,11 +147,6 @@ public class Scope extends BasicScope implements IScope, IScopeStatistics, Scope
      * Statistics about sub-scopes.
      */
     protected final transient StatisticsCounter subscopeStats = new StatisticsCounter();
-
-    /**
-     * Storage for scope attributes
-     */
-    protected final AttributeStore attributes = new AttributeStore();
 
     /**
      * Mbean object name.
@@ -392,44 +386,6 @@ public class Scope extends BasicScope implements IScope, IScopeStatistics, Scope
                 log.error("Exception during dispatching event: {}", event, e);
             }
         });
-    }
-
-    /** {@inheritDoc} */
-    public Object getAttribute(String name) {
-        return attributes.getAttribute(name);
-    }
-
-    /** {@inheritDoc} */
-    public boolean setAttribute(String name, Object value) {
-        return attributes.setAttribute(name, value);
-    }
-
-    /** {@inheritDoc} */
-    public boolean hasAttribute(String name) {
-        return attributes.hasAttribute(name);
-    }
-
-    /** {@inheritDoc} */
-    public boolean removeAttribute(String name) {
-        return attributes.removeAttribute(name);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return a {@link java.util.Set} object
-     */
-    public Set<String> getAttributeNames() {
-        return attributes.getAttributeNames();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return a {@link java.util.Map} object
-     */
-    public Map<String, Object> getAttributes() {
-        return attributes.getAttributes();
     }
 
     /**

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <name>Red5</name>
     <description>The Red5 server</description>
     <groupId>org.red5</groupId>
-    <version>2.0.19</version>
+    <version>2.0.20</version>
     <url>https://github.com/Red5/red5-server</url>
     <inceptionYear>2005</inceptionYear>
     <organization>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-server</artifactId>

--- a/server/src/main/java/org/red5/server/adapter/StatefulScopeWrappingAdapter.java
+++ b/server/src/main/java/org/red5/server/adapter/StatefulScopeWrappingAdapter.java
@@ -10,15 +10,12 @@ package org.red5.server.adapter;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import org.red5.server.api.IAttributeStore;
 import org.red5.server.api.IClient;
 import org.red5.server.api.IConnection;
 import org.red5.server.api.IContext;
 import org.red5.server.api.scope.IScope;
-import org.red5.server.api.scope.IScopeAware;
 import org.red5.server.plugin.PluginDescriptor;
 import org.springframework.core.io.Resource;
 
@@ -27,35 +24,12 @@ import org.springframework.core.io.Resource;
  *
  * @author mondain
  */
-public class StatefulScopeWrappingAdapter extends AbstractScopeAdapter implements IScopeAware, IAttributeStore {
-
-    //private static Logger log = LoggerFactory.getLogger(StatefulScopeWrappingAdapter.class);
-
-    /**
-     * Wrapped scope
-     */
-    protected volatile IScope scope;
+public class StatefulScopeWrappingAdapter extends AbstractScopeAdapter {
 
     /**
      * List of plug-in descriptors
      */
     protected List<PluginDescriptor> plugins;
-
-    /** {@inheritDoc} */
-    public void setScope(IScope scope) {
-        //log.trace("setScope: {}", scope.getName());
-        this.scope = scope;
-    }
-
-    /**
-     * Getter for wrapped scope
-     *
-     * @return Wrapped scope
-     */
-    public IScope getScope() {
-        //log.trace("getScope: {}", scope.getName());
-        return scope;
-    }
 
     /**
      * Returns any plug-ins descriptors added
@@ -74,126 +48,6 @@ public class StatefulScopeWrappingAdapter extends AbstractScopeAdapter implement
      */
     public void setPlugins(List<PluginDescriptor> plugins) {
         this.plugins = plugins;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param name a {@link java.lang.String} object
-     * @return a {@link java.lang.Object} object
-     */
-    public Object getAttribute(String name) {
-        return scope.getAttribute(name);
-    }
-
-    /** {@inheritDoc} */
-    public Object getAttribute(Enum<?> enm) {
-        return getAttribute(enm.name());
-    }
-
-    /** {@inheritDoc} */
-    public Object getAttribute(String name, Object defaultValue) {
-        Object value = scope.getAttribute(name);
-        if (value == null) {
-            value = defaultValue;
-        }
-        return value;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return a {@link java.util.Set} object
-     */
-    public Set<String> getAttributeNames() {
-        return scope.getAttributeNames();
-    }
-
-    /**
-     * Wrapper for Scope#getAttributes
-     *
-     * @return Scope attributes map
-     */
-    public Map<String, Object> getAttributes() {
-        return scope.getAttributes();
-    }
-
-    /** {@inheritDoc} */
-    public boolean hasAttribute(String name) {
-        return scope.hasAttribute(name);
-    }
-
-    /** {@inheritDoc} */
-    public boolean hasAttribute(Enum<?> enm) {
-        return hasAttribute(enm.name());
-    }
-
-    /** {@inheritDoc} */
-    public boolean removeAttribute(String name) {
-        return scope.removeAttribute(name);
-    }
-
-    /** {@inheritDoc} */
-    public boolean removeAttribute(Enum<?> enm) {
-        return removeAttribute(enm.name());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void removeAttributes() {
-        Set<String> names = scope.getAttributeNames();
-        for (String name : names) {
-            scope.removeAttribute(name);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return a int
-     */
-    public int size() {
-        return scope != null ? scope.getAttributeNames().size() : 0;
-    }
-
-    /** {@inheritDoc} */
-    public boolean setAttribute(String name, Object value) {
-        return scope.setAttribute(name, value);
-    }
-
-    /** {@inheritDoc} */
-    public boolean setAttribute(Enum<?> enm, Object value) {
-        return setAttribute(enm.name(), value);
-    }
-
-    /** {@inheritDoc} */
-    public boolean setAttributes(IAttributeStore attributes) {
-        int successes = 0;
-        for (Map.Entry<String, Object> entry : attributes.getAttributes().entrySet()) {
-            if (scope.setAttribute(entry.getKey(), entry.getValue())) {
-                successes++;
-            }
-        }
-        // expect every value to have been added
-        return (successes == attributes.size());
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param attributes a {@link java.util.Map} object
-     * @return a boolean
-     */
-    public boolean setAttributes(Map<String, Object> attributes) {
-        int successes = 0;
-        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
-            if (scope.setAttribute(entry.getKey(), entry.getValue())) {
-                successes++;
-            }
-        }
-        // expect every value to have been added
-        return (successes == attributes.size());
     }
 
     /**

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-service</artifactId>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.red5</groupId>
         <artifactId>red5-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>red5-servlet</artifactId>


### PR DESCRIPTION
* Add `setAttributeIfAbsent` to leverage concurrent backing map in `AttributeStore`
* Remove extraneous `AttributeStore` from Scope impl, its already an `AttributeStore`
* Clear extra attribute access/mutate methods
* Move methods to parent `AbstractScopeAdapter` from `StatefulScopeWrappingAdapter`
* Bump version to 2.0.20


