### PR TITLE
Bump Bouncy Castle to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <red5-moq-pkgr.version>[1.3.9,)</red5-moq-pkgr.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
-        <bc.version>1.83</bc.version>
+        <bc.version>1.84</bc.version>
         <mina.version>2.0.27</mina.version>
         <spring.version>6.2.17</spring.version>
         <tomcat.version>11.0.15</tomcat.version>


### PR DESCRIPTION
## Summary
- Bumps `bc.version` 1.83 -> 1.84 in the parent `pom.xml`.
- Clears CVE-2026-5598 (HIGH, covert timing channel) and CVE-2026-0636 (MEDIUM, LDAP injection).
- Supersedes Dependabot PR #435 (closed); same one-line change, manually authored to keep history consistent with the internal Dependabot remediation routine.

## Test plan
- [x] `mvn compile -DskipTests -fae` — all 6 reactor modules build clean (Red5 :: IO / Server Common / Service / Server / Client / Tests).
- [ ] CI green on this branch.
- [ ] Dependabot security tab shows the 2 BC alerts as resolved post-merge.