### PR TITLE
RED5DEV-2156 playengine: send live prelude at ts=0 to avoid stale bas…

### DIFF
--- a/common/src/main/java/org/red5/server/stream/PlayEngine.java
+++ b/common/src/main/java/org/red5/server/stream/PlayEngine.java
@@ -585,15 +585,18 @@ public final class PlayEngine implements IFilter, IPushableConsumer, IPipeConnec
             // get the stream so that we can grab any metadata and decoder configs
             IBroadcastStream stream = (IBroadcastStream) ((IBroadcastScope) in).getClientBroadcastStream();
             // prevent an NPE when a play list is created and then immediately flushed
+            // Prelude (metadata, decoder configs) goes out at ts=0 and the cached keyframe at
+            // ts=1 so the late-subscriber rebasing in sendMessage() does not anchor
+            // audioBaseTs/videoBaseTs to the publisher's stale cached metadata timestamp. The
+            // first live A/V frame then establishes the per-PID base and the subscriber's first
+            // real frame lands near ts=2 instead of (publisher_now - cached_metadata_ts).
             int ts = 0;
             if (stream != null) {
                 Notify metaData = stream.getMetaData();
                 //check for metadata to send
                 if (metaData != null) {
-                    ts = metaData.getTimestamp();
                     log.debug("Metadata is available");
-                    RTMPMessage metaMsg = RTMPMessage.build(metaData, metaData.getTimestamp());
-                    sendMessage(metaMsg);
+                    sendMessage(RTMPMessage.build(metaData, ts));
                 } else {
                     log.debug("No metadata available");
                 }


### PR DESCRIPTION
…eTs anchor

playLive() reused the cached metadata's timestamp for the decoder configs that precede the first live frame. The late-subscriber rebasing in sendMessage() then captured audioBaseTs/videoBaseTs from those config messages, pinning the base to a stale value (e.g. 444 ms when an M2TS-from-SRT publisher had been running long enough for its cached metadata ts to drift). The first live A/V frame became (publisher_now - cached_metadata_ts), so RTMP subscribers saw audio start at minutes-into-the-stream instead of ~0.

Push metadata, video config, and audio config at ts=0 (matching the existing "both at ts=0" comment) so none of them satisfy the eventTime > 1 baseTs capture branch. The cached keyframe stays at ts=1. The first live audio or video frame then establishes the per-PID base and lands at ts=2.

# Pull Request

This PR fixes #__Enter issue number__

Changes proposed in this pull request:
- 
- 
-


