### PR TITLE
Push docker image on demand

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push-docker-image:
-    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@4ec701169e70c9abef5abaacb7a4090a5f351fba
+    uses: Red5/docker/.github/workflows/push-docker-image.yml@4ec701169e70c9abef5abaacb7a4090a5f351fba
     with:
       version: ${{ github.event.release.tag_name }}
     secrets:

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   push-docker-image:
-    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@314b0deb22f6e92c7538b7d246fa68e806856363
+    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@58236bffcf70c52dbaf147bf38078e7a70b53e43
     with:
       version: ${{ github.event.release.tag_name }}
+    secrets:
+      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-repository: ${{ secrets.DOCKERHUB_REPOSITORY }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,12 @@
+name: Push Docker Image
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  push-docker-image:
+    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@314b0deb22f6e92c7538b7d246fa68e806856363
+    with:
+      version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push-docker-image:
-    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@58236bffcf70c52dbaf147bf38078e7a70b53e43
+    uses: Juansecu/Red5-Docker/.github/workflows/push-docker-image.yml@4ec701169e70c9abef5abaacb7a4090a5f351fba
     with:
       version: ${{ github.event.release.tag_name }}
     secrets:


### PR DESCRIPTION
# Pull Request

This PR fixes #442

Changes proposed in this pull request:
- Added a workflow to push new versions of Red5 server Docker image when a release is created in the repository `Red5/red5-server` by calling [the callable workflow added by PR `#8`](https://github.com/Red5/docker/pull/8)

    This workflow needs the following secrets to be added and configured in the `Red5/red5-server` repository:

    - `DOCKERHUB_PASSWORD` - A Docker Hub personal access token with `Read & Write` permissions
    - `DOCKERHUB_USERNAME` - The Docker Hub user account that will be used to push newer versions of the Docker image
    - `DOCKERHUB_REPOSITORY` - The Docker Hub repository where the Docker image will be pushed to (e.g. `mondain/red5-server`)