### PR TITLE
RTMP ingest: cut hot-path CPU waste and allocation churn

### DIFF
--- a/RTMP_INGEST_PERF_FIXES.md
+++ b/RTMP_INGEST_PERF_FIXES.md
@@ -89,8 +89,61 @@ Both targeted paths were eliminated; nothing untouched disappeared. Overall CPU 
 single digits (the remainder is I/O-bound), giving roughly 10% more publisher headroom
 per core.
 
-## Remaining scaling levers (not addressed here)
+Both targeted paths were eliminated; nothing untouched disappeared.
 
-- Socket write syscalls dominate (~24-29%). Coalescing per-packet writes or raising the
-  outbound RTMP chunk size would cut the number of `write()` syscalls.
-- `RTMP$ChannelInfo` was ~12% of allocations; worth investigating for reuse.
+## Follow-up: allocation and encode-path fixes
+
+After the two fixes above, profiling showed allocation (memory cost) dominated by `byte[]`
+(61.5%) and `RTMP$ChannelInfo` (12.2%). Three further fixes target the encode/decode path.
+
+### 3. `RTMP.getChannelInfo` allocated per call
+
+`common/.../net/rtmp/codec/RTMP.java`
+
+`getChannelInfo` used `channels.putIfAbsent(channelId, new ChannelInfo())`, which allocated a
+`ChannelInfo` on every call and discarded it whenever the channel already existed. The method
+is called several times per packet, so it was ~12% of all allocations. Replaced with a
+get-first idiom that allocates only when a channel is first seen. (A `computeIfAbsent` lambda
+was deliberately avoided: `ChannelInfo` is a non-static inner class, so its construction
+captures the enclosing instance and the lambda would itself be allocated per call.)
+
+### 4. Per-chunk temporary `byte[]` in the encoder
+
+`common/.../net/rtmp/codec/RTMPProtocolEncoder.java`
+
+The chunk-writing loop allocated `new byte[chunkSize]` and copied through it for every chunk
+of every outbound message. Replaced with a direct buffer-to-buffer copy (slice the source
+`IoBuffer` and `put` it), eliminating the per-chunk array allocation.
+
+### 5. Outbound chunk size raised 1024 -> 4096
+
+`common/.../stream/consumer/ConnectionConsumer.java`
+
+The outbound RTMP chunk size sent to subscribing clients was 1024 (with a "not sure of the
+best value" TODO). Raised to 4096 (the de-facto standard used by FFmpeg, OBS and nginx-rtmp),
+cutting the per-message chunk count ~4x for typical video frames - fewer chunk headers, fewer
+copies, less encoder work - with no client compatibility impact.
+
+## Combined verification
+
+Re-profiled under the identical 80-stream load with all five fixes applied:
+
+| Metric                         | Baseline | Final  | Change |
+|--------------------------------|----------|--------|--------|
+| Allocation (profiler samples)  | 14308    | 8791   | -39%   |
+| CPU (profiler samples)         | 1580     | 1392   | -12%   |
+| `RTMP$ChannelInfo` allocation  | 12.2%    | 0%     | gone   |
+| RTMP decode path CPU           | 12.2%    | ~3%    | gone   |
+| ZGC CPU                        | 2.6%     | 1.7%   | less GC|
+
+The ~39% allocation reduction is the main memory win and lowers GC frequency; CPU drops ~12%,
+with the remainder being inherent socket I/O. 80 ffmpeg subscribers consumed the re-chunked
+streams cleanly throughout, confirming encoder correctness.
+
+## Remaining scaling levers (not addressed)
+
+- Socket read/write syscalls still dominate (~38% combined) and are largely inherent to
+  per-frame low-latency relaying; coalescing writes would trade latency for fewer syscalls.
+- The inbound decoder still copies each chunk via `Arrays.copyOfRange` (`RTMPProtocolDecoder`),
+  which is the bulk of the remaining `byte[]` allocation; it could write directly into the
+  packet buffer.

--- a/RTMP_INGEST_PERF_FIXES.md
+++ b/RTMP_INGEST_PERF_FIXES.md
@@ -1,0 +1,96 @@
+# RTMP Ingest CPU/Memory Profiling and Fixes
+
+Investigation date: 2026-05-27
+
+## Symptom
+
+DevOps reported that a 2 vCPU instance saturated at roughly 20 concurrent RTMP
+publishers (plain RTMP, ~4-8 Mbps 1080p30, live fan-out to 1-5 subscribers each),
+which was lower throughput per core than expected.
+
+## Method
+
+The live system could not be profiled, so a local profiled reproduction was used:
+
+- Extracted Red5 server distribution, pinned to 2 cores (`taskset -c 0,1`) with
+  `-XX:ActiveProcessorCount=2` and the default ZGC configuration, to model a 2 vCPU box.
+- Load generated with ffmpeg streaming a pre-encoded 1080p30 / 6 Mbps file using
+  `-c copy` (no encode cost), publishers and subscribers pinned to the remaining cores
+  so they could not contaminate Red5's two cores.
+- 20 publishers x 3 subscribers = 80 concurrent streams (~480 Mbps relayed).
+- CPU and allocation profiles captured with async-profiler using the `ctimer` engine
+  (the host has `perf_event_paranoid=4`, so perf-based events are unavailable).
+
+A self-contained JMH-style micro-benchmark was also used to isolate the received-packet
+dispatch cost before profiling.
+
+## Findings (baseline CPU profile, inclusive)
+
+| Cost                                                  | % CPU | Nature                         |
+|-------------------------------------------------------|-------|--------------------------------|
+| Socket write syscalls (`SocketDispatcher.write0`)     | ~29%  | Inherent to relaying the bytes |
+| Socket read syscalls                                  | ~14%  | Inherent                       |
+| `String.format` inside `ChunkHeader.read` (trace log) | ~7.2% | Pure waste (fixed)             |
+| Fan-out + per-subscriber encode                       | ~9%   | Mostly necessary               |
+| Received-packet dispatch (vthread + join)             | ~5%   | Overhead (fixed)               |
+| ZGC                                                   | ~2.6% | Minor                          |
+
+Allocation profile: `byte[]` 61.5% (buffer copies, inherent), `RTMP$ChannelInfo` 12.2%,
+and `Matcher` + `Formatter` ~3.8% (the `ChunkHeader` `String.format` again).
+
+Headline conclusion: per-stream compute is small; the workload is dominated by socket
+I/O syscalls (~45%). The confirmed waste below is real but accounts for roughly 12% of
+compute, not a multiplier.
+
+## Fixes in this change
+
+### 1. `ChunkHeader.read` eager `String.format` in a disabled trace log
+
+`common/.../net/rtmp/message/ChunkHeader.java`
+
+`log.trace(...)` does not print in production (TRACE disabled), but its arguments are
+evaluated eagerly. `String.format("%02x", headerByte)` therefore ran on every chunk,
+parsing its format string via regex and allocating a `Formatter`/`Matcher`, only to
+discard the result. The call is now guarded with `log.isTraceEnabled()`.
+
+Impact: removes ~7% of CPU and ~3.8% of allocations on the decode path.
+
+### 2. Redundant per-packet virtual-thread dispatch
+
+`common/.../net/rtmp/RTMPConnection.java` (`handleMessageReceived`)
+
+Each received packet was wrapped in a `ReceivedMessageTask`, dispatched to a
+per-connection virtual-thread executor via `CompletableFuture.supplyAsync(...)`, and then
+immediately `join()`-ed. Because the single-threaded receiver loop blocks on the join,
+this provided no concurrency benefit while adding a virtual-thread spawn, a
+`CompletableFuture` allocation, and two context switches per packet.
+
+The task now runs inline (`task.get()`) on the per-connection receiver thread. Packet
+ordering is preserved because that loop is single-threaded. `ReceivedMessageTask.get()`
+already records handler exceptions via the connection `exception` attribute, so error
+handling is unchanged.
+
+Impact: removes the ~5% dispatch overhead and the associated context-switch and
+allocation churn (measured 3.6x throughput and 9x less allocation at saturation in an
+isolated micro-benchmark).
+
+## Verification
+
+Re-profiled under the identical 80-stream load after applying both fixes:
+
+| Frame                                   | Before | After |
+|-----------------------------------------|--------|-------|
+| `ChunkHeader.read` / `String.format`    | 7.3%   | 0.0%  |
+| regex                                   | 4.6%   | 0.0%  |
+| `CompletableFuture` / `supplyAsync`     | 12.5%  | 0.0%  |
+| RTMP decode path (total)                | 12.2%  | 3.7%  |
+
+Both targeted paths were eliminated; nothing untouched disappeared. Overall CPU dropped
+single digits (the remainder is I/O-bound), giving roughly 10% more publisher headroom
+per core.
+
+## Remaining scaling levers (not addressed here)
+
+- Socket write syscalls dominate (~24-29%). Coalescing per-packet writes or raising the
+  outbound RTMP chunk size would cut the number of `write()` syscalls.
+- `RTMP$ChannelInfo` was ~12% of allocations; worth investigating for reuse.

--- a/RTMP_INGEST_PERF_FIXES.md
+++ b/RTMP_INGEST_PERF_FIXES.md
@@ -124,26 +124,37 @@ best value" TODO). Raised to 4096 (the de-facto standard used by FFmpeg, OBS and
 cutting the per-message chunk count ~4x for typical video frames - fewer chunk headers, fewer
 copies, less encoder work - with no client compatibility impact.
 
+### 6. Per-chunk `Arrays.copyOfRange` in the decoder
+
+`common/.../net/rtmp/codec/RTMPProtocolDecoder.java`
+
+Chunk reassembly allocated `byte[] chunk = Arrays.copyOfRange(in.array(), ...)` for every chunk
+of every inbound packet, purely to transfer bytes from the input buffer into the packet buffer.
+Replaced with a direct buffer-to-buffer transfer (limit the source `IoBuffer` to the chunk and
+`buf.put(in)`), which also advances the input position so the prior explicit `skip` is removed.
+The per-chunk allocation is now only performed when TRACE logging is enabled.
+
 ## Combined verification
 
-Re-profiled under the identical 80-stream load with all five fixes applied:
+Re-profiled under the identical 80-stream load with all six fixes applied (allocation profiles
+are 15s windows; CPU samples are rate-normalized for comparison):
 
 | Metric                         | Baseline | Final  | Change |
 |--------------------------------|----------|--------|--------|
-| Allocation (profiler samples)  | 14308    | 8791   | -39%   |
-| CPU (profiler samples)         | 1580     | 1392   | -12%   |
+| Allocation (profiler samples)  | 14308    | 8236   | -42%   |
+| CPU (rate-normalized)          | 52.7/s   | 46.6/s | -12%   |
 | `RTMP$ChannelInfo` allocation  | 12.2%    | 0%     | gone   |
-| RTMP decode path CPU           | 12.2%    | ~3%    | gone   |
+| RTMP decode path CPU           | 12.2%    | ~4%    | gone   |
+| `Arrays.copyOfRange` (decode)  | present  | 0%     | gone   |
 | ZGC CPU                        | 2.6%     | 1.7%   | less GC|
 
-The ~39% allocation reduction is the main memory win and lowers GC frequency; CPU drops ~12%,
-with the remainder being inherent socket I/O. 80 ffmpeg subscribers consumed the re-chunked
-streams cleanly throughout, confirming encoder correctness.
+The ~42% allocation reduction is the main memory win and lowers GC frequency; CPU drops ~12%,
+with the remainder being inherent socket I/O. The decoder change is an allocation reduction
+(its `copyOfRange` was only ~1-2% CPU). Remaining `byte[]` allocation is dominated by the
+necessary per-packet message buffers and MINA I/O buffers. RTMPChunkingTest, OriginEdgeChunkTest
+and RTMPExtendedTimestampTest pass, and 80 ffmpeg subscribers consumed the streams cleanly.
 
 ## Remaining scaling levers (not addressed)
 
-- Socket read/write syscalls still dominate (~38% combined) and are largely inherent to
+- Socket read/write syscalls still dominate (~36-45% combined) and are largely inherent to
   per-frame low-latency relaying; coalescing writes would trade latency for fewer syscalls.
-- The inbound decoder still copies each chunk via `Arrays.copyOfRange` (`RTMPProtocolDecoder`),
-  which is the bulk of the remaining `byte[]` allocation; it could write directly into the
-  packet buffer.

--- a/common/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -1629,14 +1629,13 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
                             receivedQueueSizeUpdater.decrementAndGet(this);
                             // create a task to handle the packet
                             ReceivedMessageTask task = new ReceivedMessageTask(conn, p);
-                            // run the task
-                            CompletableFuture<Packet> future = CompletableFuture.supplyAsync(() -> task.get(), executor).exceptionally(throwable -> {
-                                log.warn("Error processing received message {} state: {}", sessionId, RTMP.states[getStateCode()], throwable);
-                                // if we have an exception, set it on the connection
-                                conn.setAttribute("exception", throwable);
-                                throw new CompletionException(throwable);
-                            });
-                            future.join();
+                            // process the packet inline on this per-connection receiver thread. Previously this was
+                            // dispatched to a per-connection virtual-thread executor and immediately join()-ed, which
+                            // added a virtual-thread spawn + CompletableFuture allocation + two context switches per
+                            // packet for no concurrency benefit (the join serialized processing anyway). Ordering is
+                            // preserved because this loop is single-threaded. ReceivedMessageTask.get() records any
+                            // handler exception via the connection "exception" attribute, matching prior behavior.
+                            task.get();
                         }
                     } while (state.getState() < RTMP.STATE_ERROR); // keep processing unless we pass the error state
                 } catch (InterruptedException e) {

--- a/common/src/main/java/org/red5/server/net/rtmp/codec/RTMP.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/codec/RTMP.java
@@ -120,9 +120,18 @@ public class RTMP {
      * @return channel info
      */
     private ChannelInfo getChannelInfo(int channelId) {
-        ChannelInfo info = channels.putIfAbsent(channelId, new ChannelInfo());
+        // get-first so the common (channel already present) path allocates nothing. This method is
+        // called several times per packet; the previous putIfAbsent(channelId, new ChannelInfo())
+        // allocated a ChannelInfo on every call and discarded it on a hit (~12% of all allocations).
+        // A computeIfAbsent lambda is avoided too: ChannelInfo is a non-static inner class, so its
+        // construction captures the enclosing instance, which would allocate a capturing lambda per call.
+        ChannelInfo info = channels.get(channelId);
         if (info == null) {
-            info = channels.get(channelId);
+            info = new ChannelInfo();
+            ChannelInfo existing = channels.putIfAbsent(channelId, info);
+            if (existing != null) {
+                info = existing;
+            }
         }
         return info;
     }

--- a/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
@@ -328,15 +328,18 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
             in.position(position);
             return null;
         }
-        // get the chunk from our input
-        byte[] chunk = Arrays.copyOfRange(in.array(), in.position(), in.position() + length);
+        // transfer the chunk directly from the input buffer into the packet buffer. The previous
+        // Arrays.copyOfRange allocated a byte[] for every chunk of every inbound packet, which was the
+        // dominant byte[] allocation on the decode path under load. buf.put(in) advances in's position
+        // by length, so the old explicit in.skip(length) is no longer needed.
+        int inLimit = in.limit();
+        in.limit(in.position() + length);
         if (isTrace) {
-            log.trace("Read chunkSize: {}, length: {}, chunk: {}", readChunkSize, length, Hex.encodeHexString(chunk));
+            log.trace("Read chunkSize: {}, length: {}, chunk: {}", readChunkSize, length, Hex.encodeHexString(Arrays.copyOfRange(in.array(), in.position(), in.position() + length)));
         }
-        // move the position
-        in.skip(length);
         // put the chunk into the packet
-        buf.put(chunk);
+        buf.put(in);
+        in.limit(inLimit);
         if (buf.hasRemaining()) {
             if (isTrace) {
                 log.trace("Packet is incomplete ({},{})", buf.remaining(), buf.limit());

--- a/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolEncoder.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolEncoder.java
@@ -185,11 +185,14 @@ public class RTMPProtocolEncoder implements Constants, IEventEncoder {
                 do {
                     // encode the header
                     encodeHeader(header, lastHeader, out);
-                    // write a chunk
-                    byte[] buf = new byte[Math.min(chunkSize, data.remaining())];
-                    data.get(buf);
-                    //log.trace("Buffer: {}", Hex.encodeHexString(buf));
-                    out.put(buf);
+                    // write a chunk directly from the source buffer. The previous code allocated a
+                    // temporary byte[] per chunk and copied through it; this loop runs once per chunk
+                    // for every outbound message, so under load it was a dominant allocation source.
+                    int chunkLen = Math.min(chunkSize, data.remaining());
+                    int dataLimit = data.limit();
+                    data.limit(data.position() + chunkLen);
+                    out.put(data);
+                    data.limit(dataLimit);
                     // move header over to last header
                     lastHeader = header.clone();
                 } while (data.hasRemaining());

--- a/common/src/main/java/org/red5/server/net/rtmp/message/ChunkHeader.java
+++ b/common/src/main/java/org/red5/server/net/rtmp/message/ChunkHeader.java
@@ -147,7 +147,12 @@ public class ChunkHeader implements Constants, Cloneable, Externalizable {
             if (h.channelId < 0) {
                 throw new ProtocolException("Bad channel id: " + h.channelId);
             }
-            log.trace("CHUNK header byte {}, count {}, header {}, channel {}", String.format("%02x", headerByte), h.size, 0, h.channelId);
+            if (log.isTraceEnabled()) {
+                // String.format is evaluated eagerly as a log argument, so it must be guarded; otherwise it
+                // runs (regex-parsing its format string and allocating a Formatter) on every chunk even when
+                // TRACE is disabled. Profiling showed this single line at ~7% of decode CPU under load.
+                log.trace("CHUNK header byte {}, count {}, header {}, channel {}", String.format("%02x", headerByte), h.size, 0, h.channelId);
+            }
             return h;
         } else {
             // at least one byte for valid decode

--- a/common/src/main/java/org/red5/server/stream/consumer/ConnectionConsumer.java
+++ b/common/src/main/java/org/red5/server/stream/consumer/ConnectionConsumer.java
@@ -79,7 +79,10 @@ public class ConnectionConsumer implements IPushableConsumer, IPipeConnectionLis
     /**
      * Chunk size. Packets are sent chunk-by-chunk.
      */
-    private int chunkSize = 1024; //TODO: Not sure of the best value here
+    // Outbound RTMP chunk size sent to subscribing clients. 4096 is the de-facto standard used by
+    // FFmpeg, OBS and nginx-rtmp; raising it from 1024 cuts the per-message chunk count (and therefore
+    // chunk-header writes and encoder work) ~4x for typical video frames with no compatibility impact.
+    private int chunkSize = 4096;
 
     /**
      * Whether or not the chunk size has been sent. This seems to be required for h264.


### PR DESCRIPTION
## Summary

Profiling a 2-core, 80-stream RTMP ingest + fan-out reproduction (20 publishers x 3 subscribers, ~480 Mbps relayed) identified several hot-path CPU and allocation wastes. This PR fixes six of them. Methodology, profiles, and before/after numbers are in `RTMP_INGEST_PERF_FIXES.md`.

The workload is fundamentally socket-I/O-syscall bound (~36-45% of CPU is `read`/`write`), so these changes are real headroom rather than a multiplier.

## Changes

**Decode / dispatch**
- `ChunkHeader.read` passed `String.format("%02x", headerByte)` as an eager argument to a `log.trace` call. TRACE is disabled in production, so the result was discarded, but `String.format` still ran on every chunk (regex-parsing its format and allocating a `Formatter`/`Matcher`) for ~7% of CPU and ~3.8% of allocations. Guarded with `isTraceEnabled()`.
- `RTMPConnection.handleMessageReceived` dispatched each received packet to a per-connection virtual-thread executor via `CompletableFuture.supplyAsync(...)` then immediately `join()`-ed it. The join serialized processing anyway, so the virtual thread added a spawn, a `CompletableFuture` allocation, and two context switches per packet for no concurrency benefit (~5%). Now runs `task.get()` inline on the single-threaded receiver loop; ordering and exception handling unchanged.
- `RTMPProtocolDecoder` chunk reassembly allocated `Arrays.copyOfRange(in.array(), ...)` for every chunk of every inbound packet just to copy bytes into the packet buffer. Now transfers directly buffer-to-buffer (limit the source `IoBuffer` to the chunk and `buf.put(in)`, which also advances the input position); the intermediate `byte[]` is only allocated under TRACE.

**Allocation / encode**
- `RTMP.getChannelInfo` used `putIfAbsent(id, new ChannelInfo())`, allocating a `ChannelInfo` on every call (several times per packet) and discarding it on a hit (~12% of all allocations). Switched to a get-first idiom. A `computeIfAbsent` lambda is intentionally avoided: `ChannelInfo` is a non-static inner class, so its construction captures the enclosing instance and the lambda would itself be allocated per call.
- `RTMPProtocolEncoder` chunk loop allocated a temporary `byte[chunkSize]` and copied through it for every chunk of every outbound message. Now copies directly buffer-to-buffer by slicing the source `IoBuffer`.
- `ConnectionConsumer` outbound chunk size raised 1024 -> 4096 (the de-facto standard used by FFmpeg, OBS and nginx-rtmp), cutting per-message chunk count ~4x for typical video frames with no client compatibility impact.

## Verification

Re-profiled under an identical 80-stream load with all fixes applied (allocation profiles are 15s windows; CPU is rate-normalized):

| Metric                        | Baseline | Final  | Change |
|-------------------------------|----------|--------|--------|
| Allocation (profiler samples) | 14308    | 8236   | -42%   |
| CPU (rate-normalized)         | 52.7/s   | 46.6/s | -12%   |
| RTMP$ChannelInfo allocation   | 12.2%    | 0%     | gone   |
| RTMP decode path CPU          | 12.2%    | ~4%    | gone   |
| Arrays.copyOfRange (decode)   | present  | 0%     | gone   |
| ZGC CPU                       | 2.6%     | 1.7%   | less GC|

Unit tests pass: `RTMPChunkingTest` (24), `OriginEdgeChunkTest` (7), `RTMPExtendedTimestampTest` (9), plus connection/util tests (55 total, BUILD SUCCESS). 80 ffmpeg subscribers consumed the re-chunked streams cleanly throughout, confirming encoder/decoder correctness. A full `mvn clean test` should still run in CI before merge.

## Remaining lever (not in this PR)

- Socket read/write syscalls still dominate (~36-45% combined) and are largely inherent to per-frame low-latency relaying; coalescing writes would trade latency for fewer `write()` syscalls.
