### PR TITLE
Remove cleared client references immediately

### DIFF
--- a/common/src/main/java/org/red5/server/ClientList.java
+++ b/common/src/main/java/org/red5/server/ClientList.java
@@ -83,6 +83,9 @@ public class ClientList<E> extends AbstractList<E> {
                 break;
             }
         }
+        if (removed) {
+            removeReleased();
+        }
         return removed;
     }
 


### PR DESCRIPTION
Clean released weak references immediately after ClientList.remove(Object) clears a matching reference. Previously the cleared entry remained in the backing CopyOnWriteArrayList until a later size() call triggered removeReleased(), retaining unnecessary list entries between operations.

Testing:
- git diff --check
- Focused backing-list cleanup using the class's existing removeReleased helper.